### PR TITLE
Small images were being stretched. 

### DIFF
--- a/app/[vanityPath]/components/HeroSection.tsx
+++ b/app/[vanityPath]/components/HeroSection.tsx
@@ -37,13 +37,11 @@ export default function HeroSection({
           </Button>
         </div>
         {hasImage && (
-          <div className="w-full rounded-lg overflow-hidden shrink md:w-1/2">
-            <Image
+          <div className="w-full overflow-hidden shrink md:w-1/2">
+            <img
               src={content?.main?.image}
               alt="Campaign Hero"
-              className="w-full"
-              height={640}
-              width={1280}
+              className="max-w-full rounded-lg mx-auto"
             />
           </div>
         )}


### PR DESCRIPTION
Using `<Image>` requires the height and width to be set, but we don't know this since the images are user generated. This makes the images stretch if they are intrinsically smaller than the attributes we set. 

I tried several options to use <Image> without stretching, but didn't find a good option. 

Using the img tag seems to be the simplest option allowing us to leave those attributes null so we don't stretch images beyond their intrinsic values.