### PR TITLE
feat: add custom headers and update robots meta for SEO compliance

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,18 @@ const outfit = Outfit({ subsets: ['latin'], variable: '--outfit-font' })
 export const metadata: Metadata = {
   title: 'GoodParty.org Candidate Sites',
   description: 'GoodParty.org Candidate Sites',
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
+      'max-snippet': -1,
+      'max-image-preview': 'none',
+    },
+  },
 }
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
       index: false,
       follow: false,
       noimageindex: true,
-      'max-snippet': -1,
+      'max-snippet': 0,
       'max-image-preview': 'none',
     },
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,19 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_API_BASE: process.env.NEXT_PUBLIC_API_BASE,
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Robots-Tag',
+            value: 'noindex, nofollow, noarchive, nosnippet, noimageindex',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk SEO/config-only change that affects how crawlers treat the site (noindex/nofollow) but does not touch application logic or data handling.
> 
> **Overview**
> Adds crawler-blocking directives across the app by setting `metadata.robots` in `app/layout.tsx` (including `googleBot` overrides) and by sending a global `X-Robots-Tag` response header from `next.config.ts` for all routes to prevent indexing/snippets/caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5d351db7e9f09b9e784661d48e4398177a5cff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->