### PR TITLE
Eng 10174 claude

### DIFF
--- a/.claude/agents/code-critic.md
+++ b/.claude/agents/code-critic.md
@@ -1,0 +1,47 @@
+---
+name: code-critic
+description: Reviews recent code changes in this repo against the rule files in `ai-rules/`. Use after a substantive change (new route, edits to `WebsitePage` or any section component, change to `Website` type, change to `next.config.ts` headers, new API proxy route) to catch rule violations before opening a PR.
+---
+
+You are a strict code reviewer for `candidate-sites`. Your job is to read the recent diff and report rule violations against the rule files in `ai-rules/`. You do not write code. You report findings.
+
+## Process
+
+1. Identify the change. Run `git status` and `git diff` (uncommitted) and/or `git diff master...HEAD` (branch since fork point), depending on what the user asks for. If the scope is unclear, ask.
+2. Read the files that changed, plus enough surrounding context that you can judge whether a violation is real.
+3. Read every rule file in `ai-rules/` — every top-level `.md` file (excluding `README.md` and the `*-template.md` files, which are scaffolding, not rules) plus everything under `ai-rules/skills/`. Discover them at runtime (`ls ai-rules/*.md` and `ls ai-rules/skills/`); don't rely on a hard-coded list, since the submodule's contents change. Apply each rule against the diff.
+4. Cross-check `CLAUDE.md` — every "Never" item is a hard rule. Treat violations as Blockers. Pay special attention to:
+   - **`'use client'` on a page/layout that uses `await params` / `await searchParams` / `headers()`** — those are server-only APIs.
+   - **Direct `fetch(NEXT_PUBLIC_API_BASE)` from a client component** — must go through a proxy route in `app/api/`.
+   - **Removing or scoping the `X-Robots-Tag` header in `next.config.ts`** — load-bearing, intentional.
+   - **Edits inside `ai-rules/`** — that's a submodule; changes belong in the submodule's repo, not here.
+5. For changes to `Website` (`app/[vanityPath]/types/website.type.ts`), flag whether the editor in `gp-api` will continue to post a compatible payload to the preview route. If the change is breaking and the diff doesn't mention coordinating with `gp-api`, that's a Should-fix.
+
+## Output format
+
+Group findings by severity. Use file:line references the user can click.
+
+```
+## Blockers
+- path/file.ts:42 — <one-line description of the violation> (<rule source>)
+  Why: <one-sentence justification tied to the rule>
+  Fix: <concrete suggestion>
+
+## Should-fix
+- ...
+
+## Nits
+- ...
+
+## Looks good
+- <list of rules you checked that passed, so the user knows what was reviewed>
+```
+
+If the diff is clean, say so explicitly with the "Looks good" list — don't invent issues to fill space.
+
+## Never
+
+- Never edit files. You only read and report.
+- Never run `npm run lint:fix` / `format:fix` / any other mutating command. The user runs those themselves after reviewing your findings.
+- Never approve changes that violate a `CLAUDE.md` "Never" item — those are blockers, not nits.
+- Never claim something passes a rule you didn't actually check. If a rule file is missing or unreadable, say so.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ai-rules"]
+	path = ai-rules
+	url = https://github.com/thegoodparty/ai-rules.git

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,4 +11,5 @@ package.json
 .next/
 .storybook/
 .vscode/
-public/ 
+public/
+ai-rules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+Guidance for Claude Code and other AI agents working in `candidate-sites`. Keep this file short — push detail into `docs/`.
+
+## Project
+
+Next.js 15 (App Router) + React 19 + MUI 7 + Tailwind 3 app that renders **public candidate websites** authored in `gp-api`. Each request fetches the site's content from `gp-api` server-side and renders. Two entry points: vanity path (`/[vanityPath]`) and custom domain (`Host` header). Deployed on Vercel. There is **no auth** in this repo and **no database** — `gp-api` is the only data source. When a custom-domain request can't resolve to a published site, the route renders a minimal placeholder (just an `<h1>`); when a vanity-path request can't, it 404s. See `README.md` for the user-facing overview.
+
+## Commands (most-used first)
+
+```bash
+npm run dev              # next dev --turbopack --port 4001
+npm run build            # next build (also runs TS type-checking)
+npm run start            # next start (serve the production build)
+npm run lint             # next lint (ESLint)
+npm run lint:fix         # next lint --fix (mutates files — stage first)
+npm run format           # prettier -c .   (read-only check)
+npm run format:fix       # prettier --write . (mutates files — stage first)
+```
+
+There is **no `npm test` script** and no test framework configured. Don't add a stub `test` script — a script that does nothing (or always passes) is worse than no script.
+
+There is **no `npm run typecheck` script.** Type errors surface during `next build` and through the editor's TS server. If you need a one-shot check, run `npx tsc --noEmit`.
+
+## Pointer table — when in doubt
+
+| Doing                                                            | Read                         |
+| ---------------------------------------------------------------- | ---------------------------- |
+| App shape, env vars, deploy basics                               | `README.md`                  |
+| Adding a route, section, or data flow                            | `docs/architecture.md`       |
+| Local dev quirks (gp-api wiring, custom-domain trick, port 4001) | `docs/getting-started.md`    |
+| AI rule-by-rule code review                                      | `ai-rules/` (git submodule)  |
+| Why a thing is the way it is                                     | `docs/adr/`                  |
+
+## Code style
+
+- **No semicolons**, single quotes, trailing commas, `printWidth: 80` (`.prettierrc`).
+- `unused-imports/no-unused-imports` is **an error**.
+- `@stylistic/semi: never` is **an error** — never add a semicolon.
+- `@typescript-eslint/no-explicit-any` is **off** — but prefer typed code; `any` is a last resort.
+- TypeScript: `strict: true`, `target: ES2017`, `module: esnext`, `moduleResolution: bundler`. Path alias `@/*` → repo root (so `@/helpers/fetchHelper` resolves to `./helpers/fetchHelper`).
+- Default exports for page components and route handlers (the App Router convention). Named exports for everything else.
+- Functional React components only. `'use client'` directive at the top of files that need browser-only hooks (`useState`, `useEffect`, MUI styled components).
+
+## App layout
+
+```
+app/
+├── layout.tsx                          # root layout — global fonts/styles
+├── page.tsx                            # custom-domain entry — resolves by Host header
+├── globals.css                         # Tailwind base + globals
+├── api/
+│   ├── contact-form/[vanityPath]/route.ts   # proxies POST → gp-api /websites/{path}/contact-form
+│   └── websites/[vanityPath]/track-view/route.ts  # proxies POST → gp-api /websites/{path}/track-view
+└── [vanityPath]/
+    ├── page.tsx                        # vanity-path entry — resolves by /{vanityPath}
+    ├── preview/                        # iframe preview route — postMessage-driven
+    ├── components/                     # WebsitePage + section components (Hero/About/Contact/...)
+    ├── constants/                      # WEBSITE_THEMES, WEBSITE_SECTIONS, WEBSITE_STEPS
+    └── types/website.type.ts           # Website shape
+helpers/
+├── fetchHelper.ts                      # thin fetch wrapper around API_ROOT — returns T | null
+└── validations.ts
+appEnv.ts                               # API_ROOT + IS_PROD/IS_PREVIEW/IS_DEV/IS_LOCAL flags
+next.config.ts                          # image domains + global `X-Robots-Tag: noindex`
+```
+
+`app/[vanityPath]/components/WebsitePage.tsx` is the rendering core — both entry points hand off to it. Start there if you're adding or fixing a section.
+
+## Data flow (one paragraph)
+
+Both entry points (`app/page.tsx` for custom-domain, `app/[vanityPath]/page.tsx` for vanity-path) call `fetchHelper<Website>(...)` against `gp-api` and pass the resulting `Website` to `WebsitePage`. `WebsitePage` reads `website.content` (hero / about / contact / theme) and `website.campaign` (candidate name / level / state) and renders the section components. **There is no client-side data fetching of the site itself** — everything except the contact-form POST and view-tracking POST goes through server-side `fetch` in the route's RSC. The two `app/api/.../route.ts` proxies exist precisely so client components can `POST` without leaking the API base URL or shape.
+
+## Preview route
+
+`app/[vanityPath]/preview/page.tsx` (and its `PreviewPageClient`) is **not data-fetched**. It listens for a `WEBSITE_DATA` `postMessage` from the parent window — `gp-api`'s editor renders this route in an iframe and pushes draft content in. If you change the `Website` type, also update what the editor posts; otherwise the preview silently breaks.
+
+## Search-engine policy
+
+`next.config.ts` sets `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet, noimageindex` on **every path**. These are public sites that intentionally don't appear in search results. Don't override this header in a route without an explicit reason — it's load-bearing.
+
+## Never
+
+- Never add `'use client'` to a page or layout that's an `async` function. Client components can't be async, so anything that `await`s `params` / `searchParams` / `headers()` (or anything else) must remain a server component. If a client subtree needs that data, fetch it in the server component and pass it down as props.
+- Never call `gp-api` directly from a browser-only component. Use the proxy routes under `app/api/` so `NEXT_PUBLIC_API_BASE` (which is exposed to the client by name) doesn't end up baked into a fetch URL with no observability or auth control.
+- Never remove the `X-Robots-Tag` header in `next.config.ts` without confirming with the team — it's deliberate.
+- Never check in env values. Only `.env.example` (when added) belongs in git; real values go in Vercel project settings or local `.env.local`.
+- Never edit a file under `ai-rules/` directly — it's a submodule that points at `thegoodparty/ai-rules`. Update it via `git -C ai-rules pull` (and stage the new pin in the parent).
+
+## Environment
+
+- **Node 20+** per README; no `.nvmrc`, no `engines` field. Next 15 + React 19 + Turbopack realistically need 20+. If you pin a version, do it via `.nvmrc` and update the README in the same change.
+- **npm**, single workspace.
+- Required runtime env (set in Vercel or `.env.local`):
+  - `NEXT_PUBLIC_API_BASE` — full `gp-api` base URL including `/v1` prefix (defaults to `http://localhost:3000/v1`).
+  - `NEXT_PUBLIC_VERCEL_TARGET_ENV` — auto-set by Vercel; drives `appEnv.ts` flags.
+- The `postinstall` hook (`scripts/postinstall.js`) initializes the `ai-rules/` submodule. It's a no-op when `.gitmodules` is absent, and on failure it prints a one-line warning and exits 0 so `npm install` still succeeds — the Next build doesn't depend on `ai-rules/`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,22 @@
+# ADRs (Architecture Decision Records)
+
+Short, append-only records of non-obvious decisions in this repo. One file per decision, numbered sequentially (`0001-...md`, `0002-...md`).
+
+## When to write one
+
+Write an ADR when a decision is **load-bearing** and **non-obvious** — i.e., a future contributor (or agent) would reasonably want to change it without realizing why it was done that way. Examples worth recording:
+
+- Why two entry routes (`app/page.tsx` + `app/[vanityPath]/page.tsx`) instead of a route group.
+- Why MUI 7 **and** Tailwind 3 instead of one or the other.
+- Why `helpers/fetchHelper.ts` returns `T | null` instead of throwing.
+- Why `X-Robots-Tag: noindex` is global in `next.config.ts`.
+
+Don't write one for changes that the diff itself explains (a new section component, a copy edit, a dependency bump).
+
+## Template
+
+Use [`ai-rules/adr-template.md`](../../ai-rules/adr-template.md) as the starting point. Copy it to `docs/adr/NNNN-short-slug.md`, fill in **Context / Decision / Consequences**, and commit it alongside the change it documents.
+
+## Index
+
+_(none yet)_

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,159 @@
+# Architecture
+
+A pointer-heavy doc. Detailed conventions live in `CLAUDE.md` and `ai-rules/`.
+
+## Stack
+
+- **Next.js 15** App Router on **React 19**, dev server uses Turbopack on port `4001`.
+- **MUI 7** (`@mui/material`, `@mui/icons-material`) + **Emotion** for component styling; **Tailwind 3** for layout / utility classes; **`@tailwindcss/typography`** for prose.
+- **TypeScript 5** strict, `target: ES2017`, `module: esnext`, `moduleResolution: bundler`, path alias `@/*` → repo root.
+- **ESLint 9** with `next/core-web-vitals + next/typescript`, `unused-imports`, `@stylistic` (forbids semicolons). **Prettier 2** for formatting.
+- **Build:** `next build` (Webpack production build). **Dev:** Turbopack via `next dev --turbopack`. Restart `npm run dev` after editing `next.config.ts` or `tsconfig.json` — neither is hot-reloaded.
+- **Deploy:** Vercel. Env vars are configured per environment (`production` / `preview` / `development`); `NEXT_PUBLIC_VERCEL_TARGET_ENV` is set automatically.
+- **No tests.** No vitest / jest / Playwright config.
+
+## Two entry points (the heart of this app)
+
+Every request lands on **one of two** server-rendered routes:
+
+| Route                                     | When                                                                           | How it resolves the website                  |
+| ----------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------- |
+| `app/page.tsx` (`/`)                      | Request `Host` header is a custom candidate domain (e.g. `jane-for-mayor.com`) | `GET ${API_ROOT}/websites/by-domain/{host}`  |
+| `app/[vanityPath]/page.tsx` (`/jane-doe`) | Request hits the GoodParty.org parent domain at a vanity slug                  | `GET ${API_ROOT}/websites/{vanityPath}/view` |
+
+Both call `fetchHelper<Website>(...)` and hand the resulting `Website` object to **`app/[vanityPath]/components/WebsitePage.tsx`**, which is the single rendering core. The custom-domain entry imports from the vanity-path tree on purpose — there's one set of components, two ways to find which `Website` to feed them.
+
+If `website.status !== 'published'`:
+
+- The vanity-path route calls `notFound()` → renders `not-found.tsx` (or the default 404).
+- The custom-domain route renders an inline minimal placeholder (just an `<h1>` — see `app/page.tsx`).
+
+## Module shape
+
+```
+app/
+├── layout.tsx                              # root <html>/<body> + global font + Tailwind globals
+├── globals.css                             # @tailwind base/components/utilities + custom CSS
+├── page.tsx                                # custom-domain entry
+├── api/                                    # server-side proxy endpoints (see "API proxy routes" below)
+│   ├── contact-form/[vanityPath]/route.ts
+│   └── websites/[vanityPath]/track-view/route.ts
+├── shared/                                 # reused across entries
+│   ├── buttons/   inputs/   typography/    # MUI / Tailwind wrappers
+│   └── utils/                              # candidateMetaData, getImageDimensions, getUserFullName, etc.
+└── [vanityPath]/
+    ├── page.tsx                            # vanity-path entry
+    ├── preview/                            # iframe-driven preview (postMessage)
+    │   ├── page.tsx
+    │   └── PreviewPageClient.tsx           # 'use client' — listens for WEBSITE_DATA messages
+    ├── components/                         # WebsitePage + section components
+    │   ├── WebsitePage.tsx                 # the rendering core
+    │   ├── HeroSection.tsx
+    │   ├── AboutSection.tsx
+    │   ├── ContactSection.tsx
+    │   ├── PrivacyPolicyModal.tsx
+    │   ├── WebsiteHeader.tsx
+    │   ├── WebsiteFooter.tsx
+    │   └── WebsiteViewTracker.tsx          # 'use client' — fires the track-view POST
+    ├── constants/                          # theme palette + nav step definitions
+    │   ├── websiteContent.const.ts         # WEBSITE_THEMES (color tokens per theme name)
+    │   └── websiteNavigation.const.ts      # WEBSITE_SECTIONS, WEBSITE_STEPS
+    └── types/website.type.ts               # the Website shape (mirrors gp-api's website model)
+helpers/
+├── fetchHelper.ts                          # fetch wrapper — returns T | null, swallows non-2xx
+└── validations.ts
+appEnv.ts                                   # API_ROOT, IS_PROD/IS_PREVIEW/IS_DEV/IS_LOCAL flags
+next.config.ts                              # image domains, NEXT_PUBLIC_API_BASE, X-Robots-Tag header
+```
+
+`WebsitePage.tsx` is the canonical reference for how a section is wired up.
+
+## Data flow
+
+```
+Browser request (vanity path or custom domain)
+        │
+        ▼  Next.js routing
+    app/page.tsx   OR   app/[vanityPath]/page.tsx
+        │                       │
+        │  Host header          │  params.vanityPath
+        ▼                       ▼
+    fetchHelper<Website>('websites/by-domain/' + host)
+    fetchHelper<Website>('websites/' + vanityPath + '/view')
+        │
+        ▼
+    Website | null
+        │     └─ null  → notFound() / fallback page
+        ▼
+    <WebsitePage website={...} privacyPolicy={?} imageDimensions={?} />
+        │
+        ▼  React Server Component → HTML to browser
+    Browser hydrates 'use client' children:
+      • WebsiteViewTracker → POST /api/websites/[vanityPath]/track-view (proxy → gp-api)
+      • Contact form       → POST /api/contact-form/[vanityPath]       (proxy → gp-api)
+      • PrivacyPolicyModal → toggled via ?privacy=true
+```
+
+Every server-side fetch goes through `helpers/fetchHelper.ts`, which:
+
+- Prefixes `${API_ROOT}/`.
+- JSON-stringifies object bodies.
+- Returns `T | null` on any non-2xx, empty body, or JSON parse error — by design, **callers never throw**, they just check for `null` and fall back.
+
+## API proxy routes
+
+`app/api/contact-form/[vanityPath]/route.ts` and `app/api/websites/[vanityPath]/track-view/route.ts` are **server-side proxies**. Client components POST to these Next routes; the routes re-call `gp-api` via `fetchHelper`. This pattern exists so:
+
+- Browser code never directly calls `gp-api`. The base URL is `NEXT_PUBLIC_*` so it would technically work, but the proxy gives us a place to add headers / observability / rate limiting later without touching browser code.
+- Cross-origin / CORS doesn't enter the picture.
+
+If you add a new client → gp-api write path, add a proxy route. Don't `fetch(NEXT_PUBLIC_API_BASE)` from a client component.
+
+## Preview route
+
+`app/[vanityPath]/preview/page.tsx` is rendered inside an iframe by `gp-api`'s editor and **does not fetch its own data**. `PreviewPageClient.tsx` listens for `window.message` events of shape `{ type: 'WEBSITE_DATA', data: Website, step?: number }` and re-renders `WebsitePage` with that data. Two implications:
+
+1. The preview route trusts whatever the parent posts. It only works inside `gp-api`'s editor frame.
+2. Changes to the `Website` type **must** be coordinated with the editor in `gp-api` — otherwise the editor posts a payload the preview can't render and the iframe goes blank.
+
+## Cross-service edges
+
+| Direction                      | Service         | Protocol               | Auth                  | Notes                                      |
+| ------------------------------ | --------------- | ---------------------- | --------------------- | ------------------------------------------ |
+| outbound (RSC + proxy routes)  | `gp-api`        | HTTP via `fetchHelper` | none                  | Public read endpoints + public-form writes |
+| inbound (iframe `postMessage`) | `gp-api` editor | `window.postMessage`   | none (origin-trusted) | Preview route only                         |
+
+There is **no `Authorization` header** anywhere in this repo. The endpoints we hit on `gp-api` are public. If that ever changes, plumbing a token would mean: add it as a server-only env var, accept it inside the proxy routes only, and never expose it to the browser bundle.
+
+## Bootstrap
+
+There's no app bootstrap to speak of. Next.js owns the lifecycle:
+
+1. `next.config.ts` ships image-domain allowlist + the global `X-Robots-Tag` header + the `NEXT_PUBLIC_API_BASE` env passthrough.
+2. `app/layout.tsx` sets up `<html>`/`<body>`, fonts, and global CSS.
+3. Each page is an async server component; it `await`s `params` / `searchParams` / `headers()`, fetches its data, and returns JSX.
+4. `'use client'` sub-trees hydrate in the browser.
+
+## Search-engine policy
+
+`next.config.ts`:
+
+```ts
+async headers() {
+  return [{ source: '/:path*', headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow, noarchive, nosnippet, noimageindex' }] }]
+}
+```
+
+Every path on every domain is blocked from search engines. This is intentional — these are personal candidate sites and we don't want them ranking organically. Removing or scoping this header is a product decision, not a bug fix.
+
+## Key patterns
+
+- **Two entries, one renderer.** New site features go in `WebsitePage` and its section components, not in either entry route.
+- **Types come from `[vanityPath]/types/website.type.ts`.** When `gp-api` ships a type contract for the website model, switch this to a re-export and delete the local copy. Until then, this file is the source of truth.
+- **`fetchHelper` returns `T | null`, never throws.** New callers should follow the same shape — return null for "not found" / "API hiccup" and let the page decide what to render.
+- **Proxy, don't fetch directly.** Browser → `/api/...` → gp-api. Always two hops for writes; one server-side hop for reads.
+- **`appEnv.ts` is the only place env-derived flags live.** Don't sprinkle `process.env.NEXT_PUBLIC_*` reads through component code — import the named flag from `appEnv`.
+
+## ADRs
+
+`docs/adr/` exists but is empty. Add one when a non-obvious decision lands (e.g., why two entries instead of route groups, why MUI + Tailwind both, why `fetchHelper` returns `null` instead of throwing, why `noindex` everywhere). Use `ai-rules/adr-template.md` as the starting point and number sequentially (`0001-...md`, `0002-...md`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,137 @@
+# Getting Started
+
+First-time setup for `candidate-sites` on macOS / Linux. The user-facing overview lives in `README.md` — this doc covers Claude-specific dev quirks and gotchas that the README doesn't.
+
+## Prerequisites
+
+- **Node 20+** (no `.nvmrc` is committed; Next.js 15 + React 19 + Turbopack realistically need 20+).
+- **npm** (a `package-lock.json` is committed).
+- A reachable `gp-api` to read website data from. Easiest is a local `gp-api` on port 3000 — see [`thegoodparty/gp-api`](https://github.com/thegoodparty/gp-api) for setup.
+
+## Clone
+
+This repo uses `ai-rules` as a git submodule. Clone with `--recursive`:
+
+```bash
+git clone --recursive git@github.com:thegoodparty/candidate-sites.git
+cd candidate-sites
+```
+
+If you already cloned without `--recursive`:
+
+```bash
+git submodule update --init --recursive
+```
+
+`npm install` runs the same command via the `postinstall` hook (`scripts/postinstall.js`), so a forgotten `--recursive` self-corrects on the next install. The hook:
+
+- No-ops when `.gitmodules` is absent (tarball / non-git contexts).
+- On failure, prints a one-line warning and **exits 0** so `npm install` still succeeds. If you see that warning, run `git submodule update --init --recursive` manually — `ai-rules/` will be empty until you do, but the Next build does not depend on it.
+
+## Configure environment
+
+Create `.env.local` at the repo root:
+
+```bash
+# Required (defaults to http://localhost:3000/v1 if unset)
+NEXT_PUBLIC_API_BASE=http://localhost:3000/v1
+```
+
+| Var                             | Default for local          | Notes                                                                                                                                                                                        |
+| ------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_API_BASE`          | `http://localhost:3000/v1` | Full `gp-api` base URL **including** the `/v1` prefix. Used by `appEnv.ts` and `helpers/fetchHelper.ts`.                                                                                     |
+| `NEXT_PUBLIC_VERCEL_TARGET_ENV` | (unset)                    | Vercel sets this automatically on hosted envs (`production` / `preview` / `development`). Locally it's unset; `IS_LOCAL` is then derived from `NEXT_PUBLIC_API_BASE` containing `localhost`. |
+
+There is no auth env. This repo doesn't talk to any system that requires a token — `gp-api`'s public endpoints are the entire surface.
+
+## Install + run
+
+```bash
+npm install      # also fires postinstall → submodule init
+npm run dev      # http://localhost:4001 (Turbopack)
+```
+
+The dev port is **4001** (set in `package.json`'s `dev` script). If you also run `gp-api` on 3000 and something else on 4000, no conflict.
+
+### Verifying the install
+
+```bash
+ls ai-rules/             # should NOT be empty (submodule init worked)
+ls dist/ 2>/dev/null     # there is no dist/ — build outputs go to .next/
+```
+
+## Talking to a local `gp-api`
+
+Both entry points need at least one `published` website in `gp-api` to render anything other than the fallback. Two flows:
+
+### Vanity-path flow (the easy one)
+
+```bash
+# Find a published vanity path in your local gp-api, then visit:
+open http://localhost:4001/<vanityPath>
+```
+
+The page calls `GET ${API_ROOT}/websites/<vanityPath>/view`. If that returns null or the website's `status !== 'published'`, you'll get a 404.
+
+### Custom-domain flow (the trickier one)
+
+The custom-domain route reads the request `Host` header and calls `GET ${API_ROOT}/websites/by-domain/{host}`. To exercise this locally without registering a domain:
+
+1. Pick a domain that's registered in your local `gp-api` (e.g. `jane-for-mayor.com`).
+2. Add it to `/etc/hosts`:
+   ```bash
+   sudo sh -c 'echo "127.0.0.1 jane-for-mayor.com" >> /etc/hosts'
+   ```
+3. (macOS only, if the change doesn't take effect) flush DNS:
+   ```bash
+   sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+   ```
+4. Visit `http://jane-for-mayor.com:4001` (note the explicit port — `/etc/hosts` only maps the hostname, not the port).
+
+Remember to remove the line when you're done.
+
+### Preview-route flow
+
+`app/[vanityPath]/preview/page.tsx` is **iframe-only** — it doesn't fetch its own data. Direct visits show "Loading preview..." for 3 seconds and then 404. To exercise it, run `gp-api`'s editor against this dev server (`gp-api` embeds `http://localhost:4001/<vanity>/preview` in an iframe and posts a `WEBSITE_DATA` message).
+
+## Verify (the same things CI / production runs)
+
+```bash
+npm run lint        # next lint  — read-only
+npm run format      # prettier -c .  — read-only
+npm run build       # next build  — type-checks during build
+```
+
+`next build` is the only thing that actually type-checks the whole repo. There's no separate `typecheck` script. Run `npx tsc --noEmit` if you want a type-only check.
+
+## Linting / formatting
+
+```bash
+npm run lint:fix     # next lint --fix; mutates files — stage first
+npm run format:fix   # prettier --write .; mutates files — stage first
+```
+
+`next lint --fix` will rewrite formatting + auto-fixable rules across the touched files. Stage your work before running it so you can audit the diff.
+
+## Deployment
+
+This repo deploys to Vercel. There's nothing to do here — Vercel watches `master` (or whichever branch is configured as the production branch). Make sure each Vercel environment has the right `NEXT_PUBLIC_API_BASE` pointed at the corresponding `gp-api` environment.
+
+There are **no tests** wired into CI. If you add tests, add the framework and the CI step in the same change.
+
+## Common gotchas
+
+- **`ai-rules/` is empty after clone** → run `git submodule update --init --recursive`, or `npm install` to trigger the `postinstall` hook.
+- **404 on a vanity path that should work** → `gp-api` returns null or the site's `status` isn't `published`. Check the response in your gp-api logs.
+- **Custom-domain route 404s but `/etc/hosts` entry exists** → you forgot the `:4001` port. The browser only adds default ports (`:80` / `:443`); a local dev server on 4001 needs to be explicit in the URL.
+- **`Failed to parse JSON response`** in the dev console → `fetchHelper` got a non-JSON body. Usually means `gp-api` returned an HTML error page; check the request shape.
+- **Type error after editing `Website`** → `gp-api`'s editor posts a `Website`-shaped payload to the preview route. If you tighten the type here, also coordinate with the editor in `gp-api` so it keeps posting valid data.
+- **Hot reload not picking up a file** → Turbopack occasionally misses changes outside `app/`. Restart `npm run dev` if a `helpers/` or `appEnv.ts` change isn't reflected.
+- **`NEXT_PUBLIC_API_BASE` change doesn't take effect** → it's read at build/start time, not on every request. Restart the dev server after editing `.env.local`.
+
+## Where to go next
+
+- `README.md` — user-facing overview (start here if you're a new contributor).
+- `CLAUDE.md` — agent + style guide for the repo.
+- `docs/architecture.md` — module shape, two-entries-one-renderer design, data flow.
+- `ai-rules/` — org-wide review rules and skills (submodule).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "postinstall": "node scripts/postinstall.js",
     "dev": "next dev --turbopack --port 4001",
     "build": "next build",
     "start": "next start",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/* eslint-disable */
+// Initializes the `ai-rules` git submodule on `npm install`.
+// - No-op if `.gitmodules` is missing (e.g. tarball / non-git contexts).
+// - On failure, prints a one-line warning and exits 0 so `npm install` still succeeds.
+//   `ai-rules/` is only consumed by the `code-critic` agent locally; the Next build
+//   does not depend on it.
+
+const fs = require('fs')
+const { execSync } = require('child_process')
+
+if (!fs.existsSync('.gitmodules')) {
+  process.exit(0)
+}
+
+try {
+  execSync('git submodule update --init --recursive', { stdio: 'inherit' })
+} catch (err) {
+  console.warn(
+    '[postinstall] Warning: failed to initialize git submodules. ' +
+      '`ai-rules/` will be empty. Run `git submodule update --init --recursive` manually. ' +
+      `(${err && err.message ? err.message : err})`,
+  )
+  process.exit(0)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a `postinstall` script that runs `git submodule update`, which changes install-time behavior and could affect CI or non-git install environments (though it no-ops/fails open). Otherwise changes are documentation and tooling-only with no production runtime impact.
> 
> **Overview**
> Introduces the `ai-rules/` git submodule and wires it into `npm install` via a new `postinstall` script (`scripts/postinstall.js`) that initializes submodules when `.gitmodules` is present.
> 
> Adds Claude/agent workflow documentation (`CLAUDE.md`, `docs/architecture.md`, `docs/getting-started.md`, `docs/adr/README.md`) plus a new `.claude/agents/code-critic.md` reviewer agent spec, and updates `.prettierignore` to exclude `ai-rules/` (and normalizes the `public/` entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559e071df7982347083235d8f3e27304036459a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->