### PR TITLE
chore(lint): replace deprecated next lint with ESLint CLI (monorepo prep)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ Next.js 15 (App Router) + React 19 + MUI 7 + Tailwind 3 app that renders **publi
 npm run dev              # next dev --turbopack --port 4001
 npm run build            # next build (also runs TS type-checking)
 npm run start            # next start (serve the production build)
-npm run lint             # next lint (ESLint)
-npm run lint:fix         # next lint --fix (mutates files — stage first)
+npm run lint             # eslint . (ESLint CLI, flat config)
+npm run lint:fix         # eslint . --fix (mutates files — stage first)
 npm run format           # prettier -c .   (read-only check)
 npm run format:fix       # prettier --write . (mutates files — stage first)
 ```

--- a/app/shared/inputs/PhoneInput.tsx
+++ b/app/shared/inputs/PhoneInput.tsx
@@ -55,6 +55,9 @@ function PhoneInput({
     if (value !== displayValue) {
       setDisplayValue(value || '')
     }
+    // Intentionally only re-sync when the external `value` prop changes;
+    // depending on `displayValue` would re-run this on every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value])
 
   const onChangeValue = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,15 @@ const compat = new FlatCompat({
 })
 
 const eslintConfig = [
+  {
+    ignores: [
+      '.next/**',
+      'out/**',
+      'build/**',
+      'next-env.d.ts',
+      'ai-rules/**',
+    ],
+  },
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   ...compat.config({
     plugins: ['react', 'unused-imports', '@stylistic'],
@@ -29,6 +38,13 @@ const eslintConfig = [
       'unused-imports/no-unused-imports': 'error',
       '@stylistic/semi': ['error', 'never'],
       '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    // CommonJS config files (e.g. tailwind.config.js) legitimately use require().
+    files: ['**/*.config.{js,cjs}'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
     },
   },
 ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --turbopack --port 4001",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "format": "prettier -c .",
     "format:fix": "prettier --write ."

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dev": "next dev --turbopack --port 4001",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier -c .",
     "format:fix": "prettier --write ."
   },


### PR DESCRIPTION
## Monorepo prep

`next lint` is deprecated in Next 15 (removed in Next 16). This switches the lint scripts to run the ESLint CLI directly against the existing flat config so linting keeps working under the upcoming **omni** monorepo.

### Changes
- `lint` -> `eslint .`, `lint:fix` -> `eslint . --fix`
- Add global `ignores` for build artifacts (`.next`, `out`, `build`, `next-env.d.ts`, `ai-rules`)
- Allow CommonJS `require()` in `*.config.{js,cjs}` (e.g. `tailwind.config.js`) — these files are now covered by `eslint .` but were skipped by `next lint`
- Update stale `next lint` references in `CLAUDE.md`

### Validation (local — repo has no CI today)
- `npm run lint` passes (0 errors, 1 pre-existing warning); confirmed 46 files linted and 21 `@next/next/*` rules active in the resolved config
- `npm run build` succeeds

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 40e7f60e86db083f2ed662fe4e5e354fecc1463b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->