### PR TITLE
chore(format): upgrade Prettier to v3 + reformat (monorepo prep)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,13 @@ There is **no `npm run typecheck` script.** Type errors surface during `next bui
 
 ## Pointer table — when in doubt
 
-| Doing                                                            | Read                         |
-| ---------------------------------------------------------------- | ---------------------------- |
-| App shape, env vars, deploy basics                               | `README.md`                  |
-| Adding a route, section, or data flow                            | `docs/architecture.md`       |
-| Local dev quirks (gp-api wiring, custom-domain trick, port 4001) | `docs/getting-started.md`    |
-| AI rule-by-rule code review                                      | `ai-rules/` (git submodule)  |
-| Why a thing is the way it is                                     | `docs/adr/`                  |
+| Doing                                                            | Read                        |
+| ---------------------------------------------------------------- | --------------------------- |
+| App shape, env vars, deploy basics                               | `README.md`                 |
+| Adding a route, section, or data flow                            | `docs/architecture.md`      |
+| Local dev quirks (gp-api wiring, custom-domain trick, port 4001) | `docs/getting-started.md`   |
+| AI rule-by-rule code review                                      | `ai-rules/` (git submodule) |
+| Why a thing is the way it is                                     | `docs/adr/`                 |
 
 ## Code style
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-# **Good Party Open Source License (GPOSL) v1.0** 
+# **Good Party Open Source License (GPOSL) v1.0**
 
 Copyright (c) \[2025\] \[GoodParty.org\]
 
@@ -12,7 +12,7 @@ GoodParty.org, candidates commit to a simple but powerful pledge rooted in four 
 
 “License” refers to this Good Party Open Source License.  
 “You” refers to the licensee using or redistributing the Software.  
-“Ethical Use” means use consistent with internationally recognized human rights principles and the Good Party Pledge:   
+“Ethical Use” means use consistent with internationally recognized human rights principles and the Good Party Pledge:  
 “Unethical Use” includes but is not limited to partisan political operations, disinformation, corruption, coercion, discrimination, or exploitation.
 
 ## **1\. Grant**
@@ -53,4 +53,3 @@ This License terminates automatically upon breach. The Licensor reserves the rig
 ## **7\. Disclaimer**
 
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM OR DAMAGE RESULTING FROM UNETHICAL OR UNAUTHORIZED USE.
-

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ There is also a preview route at `app/[vanityPath]/preview/page.tsx` used by `gp
 
 Create a `.env.local` (or set these in your deployment environment):
 
-| Variable | Description | Example |
-| --- | --- | --- |
-| `NEXT_PUBLIC_API_BASE` | Base URL of `gp-api`, including the version prefix. Falls back to `http://localhost:3000/v1` when unset. | `https://gp-api.goodparty.org/v1` |
-| `NEXT_PUBLIC_VERCEL_TARGET_ENV` | Set automatically on Vercel (`production` / `preview` / `development`); used by `appEnv.ts` flags. | `production` |
+| Variable                        | Description                                                                                              | Example                           |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `NEXT_PUBLIC_API_BASE`          | Base URL of `gp-api`, including the version prefix. Falls back to `http://localhost:3000/v1` when unset. | `https://gp-api.goodparty.org/v1` |
+| `NEXT_PUBLIC_VERCEL_TARGET_ENV` | Set automatically on Vercel (`production` / `preview` / `development`); used by `appEnv.ts` flags.       | `production`                      |
 
 ## Getting started
 
@@ -54,13 +54,13 @@ To exercise the **custom-domain** flow locally, point a hostname at `localhost:4
 
 ## Scripts
 
-| Script | Description |
-| --- | --- |
-| `npm run dev` | Start the Next.js dev server (Turbopack, port 4001). |
-| `npm run build` | Production build. |
-| `npm run start` | Run the production build. |
-| `npm run lint` / `lint:fix` | ESLint. |
-| `npm run format` / `format:fix` | Prettier. |
+| Script                          | Description                                          |
+| ------------------------------- | ---------------------------------------------------- |
+| `npm run dev`                   | Start the Next.js dev server (Turbopack, port 4001). |
+| `npm run build`                 | Production build.                                    |
+| `npm run start`                 | Run the production build.                            |
+| `npm run lint` / `lint:fix`     | ESLint.                                              |
+| `npm run format` / `format:fix` | Prettier.                                            |
 
 ## Project layout
 

--- a/app/[vanityPath]/components/ContactSection.tsx
+++ b/app/[vanityPath]/components/ContactSection.tsx
@@ -98,148 +98,163 @@ export default function ContactSection({
     >
       <div className="max-w-2xl mx-auto px-8 text-center">
         <Element name={WEBSITE_SECTIONS.CONTACT}>
-        <h2 className="font-semibold text-2xl mb-2">Send Me a Message</h2>
-        <p className="mb-6">
-          Have questions or suggestions? I would love to hear from you!
-        </p>
+          <h2 className="font-semibold text-2xl mb-2">Send Me a Message</h2>
+          <p className="mb-6">
+            Have questions or suggestions? I would love to hear from you!
+          </p>
 
-        {submitted ? (
-          <div
-            className={`p-6 rounded-lg text-center ${activeTheme.secondary} ${activeTheme.text} ${activeTheme.border}`}
-          >
-            Thank you for your message!
-          </div>
-        ) : (
-          <form
-            className={`p-8 rounded-lg ${activeTheme.bg} ${activeTheme.text} shadow-sm space-y-6`}
-            onSubmit={handleSubmit}
-          >
-            <div className="mb-4">
-              <TextField
-                value={formData.name || ''}
-                label="Your Name"
-                name="name"
-                fullWidth
-                required
-                placeholder="John Doe"
-                onChange={(e) => handleChange('name', e.target.value)}
-                sx={muiInputSx}
-                InputLabelProps={{ shrink: true }}
-              />
+          {submitted ? (
+            <div
+              className={`p-6 rounded-lg text-center ${activeTheme.secondary} ${activeTheme.text} ${activeTheme.border}`}
+            >
+              Thank you for your message!
             </div>
-            <div className="mb-4">
-              <EmailInput
-                value={formData.email || ''}
-                required
-                placeholder="john@example.com"
-                onChangeCallback={(e) => handleChange('email', e.target.value)}
-                sx={muiInputSx}
-                InputLabelProps={{ shrink: true }}
-              />
-            </div>
-            <div className="mb-4">
-              <PhoneInput
-                value={formData.phone || ''}
-                hideIcon
-                shrink
-                onChangeCallback={(phone) => handleChange('phone', phone)}
-                sx={muiInputSx}
-                InputLabelProps={{ shrink: true }}
-              />
-            </div>
-            <div className="mb-4">
-              <TextField
-                value={formData.message || ''}
-                label="Message"
-                name="message"
-                fullWidth
-                required
-                multiline
-                rows={4}
-                placeholder="How can we help you?"
-                onChange={(e) => handleChange('message', e.target.value)}
-                sx={muiInputSx}
-                InputLabelProps={{ shrink: true }}
-              />
-            </div>
-            <div className="flex items-start space-x-2">
-              <Checkbox
-                id="sms-consent"
-                checked={formData.smsConsent}
-                onChange={(e) =>
-                  handleChange('smsConsent', e.target.checked === true)
-                }
-                theme={{
-                  muiColor: activeTheme.muiColor
-                }}
-              />
-              <label htmlFor="sms-consent" className="text-xs text-left">
-              By providing your telephone number and checking this box, you consent to receive calls and text messages. Msg & data rates may apply. Msg frequency may vary. Messaging may include requests for donations.
-              Reply &quot;STOP&quot; to opt-out &quot;HELP&quot; for help. View our{' '}
-                <Link
-                  href={getModalHref(pathname, searchParams.toString(), 'privacy')}
-                  scroll={false}
-                  className="text-blue-600 underline hover:text-blue-700"
+          ) : (
+            <form
+              className={`p-8 rounded-lg ${activeTheme.bg} ${activeTheme.text} shadow-sm space-y-6`}
+              onSubmit={handleSubmit}
+            >
+              <div className="mb-4">
+                <TextField
+                  value={formData.name || ''}
+                  label="Your Name"
+                  name="name"
+                  fullWidth
+                  required
+                  placeholder="John Doe"
+                  onChange={(e) => handleChange('name', e.target.value)}
+                  sx={muiInputSx}
+                  InputLabelProps={{ shrink: true }}
+                />
+              </div>
+              <div className="mb-4">
+                <EmailInput
+                  value={formData.email || ''}
+                  required
+                  placeholder="john@example.com"
+                  onChangeCallback={(e) =>
+                    handleChange('email', e.target.value)
+                  }
+                  sx={muiInputSx}
+                  InputLabelProps={{ shrink: true }}
+                />
+              </div>
+              <div className="mb-4">
+                <PhoneInput
+                  value={formData.phone || ''}
+                  hideIcon
+                  shrink
+                  onChangeCallback={(phone) => handleChange('phone', phone)}
+                  sx={muiInputSx}
+                  InputLabelProps={{ shrink: true }}
+                />
+              </div>
+              <div className="mb-4">
+                <TextField
+                  value={formData.message || ''}
+                  label="Message"
+                  name="message"
+                  fullWidth
+                  required
+                  multiline
+                  rows={4}
+                  placeholder="How can we help you?"
+                  onChange={(e) => handleChange('message', e.target.value)}
+                  sx={muiInputSx}
+                  InputLabelProps={{ shrink: true }}
+                />
+              </div>
+              <div className="flex items-start space-x-2">
+                <Checkbox
+                  id="sms-consent"
+                  checked={formData.smsConsent}
+                  onChange={(e) =>
+                    handleChange('smsConsent', e.target.checked === true)
+                  }
+                  theme={{
+                    muiColor: activeTheme.muiColor,
+                  }}
+                />
+                <label htmlFor="sms-consent" className="text-xs text-left">
+                  By providing your telephone number and checking this box, you
+                  consent to receive calls and text messages. Msg & data rates
+                  may apply. Msg frequency may vary. Messaging may include
+                  requests for donations. Reply &quot;STOP&quot; to opt-out
+                  &quot;HELP&quot; for help. View our{' '}
+                  <Link
+                    href={getModalHref(
+                      pathname,
+                      searchParams.toString(),
+                      'privacy',
+                    )}
+                    scroll={false}
+                    className="text-blue-600 underline hover:text-blue-700"
+                  >
+                    Privacy Policy
+                  </Link>{' '}
+                  and{' '}
+                  <Link
+                    href={getModalHref(
+                      pathname,
+                      searchParams.toString(),
+                      'sms-terms',
+                    )}
+                    scroll={false}
+                    className="text-blue-600 underline hover:text-blue-700"
+                  >
+                    SMS Terms
+                  </Link>{' '}
+                  for more info.
+                </label>
+              </div>
+              <div className="mt-4">
+                <Button
+                  type="submit"
+                  disabled={
+                    loading ||
+                    !formData.name ||
+                    !formData.email ||
+                    !formData.message
+                  }
+                  loading={loading}
+                  color="primary"
+                  size="large"
+                  theme={{
+                    accent: activeTheme.accent,
+                    accentText: activeTheme.accentText,
+                  }}
                 >
-                  Privacy Policy
-                </Link>{' '}
-                and{' '}
-                <Link
-                  href={getModalHref(
-                    pathname,
-                    searchParams.toString(),
-                    'sms-terms',
-                  )}
-                  scroll={false}
-                  className="text-blue-600 underline hover:text-blue-700"
-                >
-                  SMS Terms
-                </Link>{' '}
-                for more info.
-              </label>
-            </div>
-            <div className="mt-4">
-              <Button
-                type="submit"
-                disabled={
-                  loading ||
-                  !formData.name ||
-                  !formData.email ||
-                  !formData.message
-                }
-                loading={loading}
-                color="primary"
-                size="large"
-                theme={{
-                  accent: activeTheme.accent,
-                  accentText: activeTheme.accentText
-                }}
-              >
-                Send Message
-              </Button>
-            </div>
-          </form>
-        )}
-  </Element>
-  <Element name={WEBSITE_SECTIONS.CONTACT_INFO}>
-        <div className="mt-8 text-center">
-          <p className="font-medium">Campaign Headquarters</p>
-          <p className="mt-1">{content?.contact?.address || ''}</p>
-          {content?.contact?.email && (
-          <p className="mt-1">
-            <a href={`mailto:${content.contact.email}`} className="hover:text-blue-600 underline ">
-              {content.contact.email}
-              </a>
-          </p>
-        )}
-          {content?.contact?.phone && (
-          <p className="mt-1">
-            <a href={phoneUri(content.contact.phone)} className="hover:text-blue-600 underline ">
-              {formatPhoneNumber(content.contact.phone)}
-              </a>
-          </p>
+                  Send Message
+                </Button>
+              </div>
+            </form>
           )}
-        </div>
+        </Element>
+        <Element name={WEBSITE_SECTIONS.CONTACT_INFO}>
+          <div className="mt-8 text-center">
+            <p className="font-medium">Campaign Headquarters</p>
+            <p className="mt-1">{content?.contact?.address || ''}</p>
+            {content?.contact?.email && (
+              <p className="mt-1">
+                <a
+                  href={`mailto:${content.contact.email}`}
+                  className="hover:text-blue-600 underline "
+                >
+                  {content.contact.email}
+                </a>
+              </p>
+            )}
+            {content?.contact?.phone && (
+              <p className="mt-1">
+                <a
+                  href={phoneUri(content.contact.phone)}
+                  className="hover:text-blue-600 underline "
+                >
+                  {formatPhoneNumber(content.contact.phone)}
+                </a>
+              </p>
+            )}
+          </div>
         </Element>
       </div>
     </section>

--- a/app/[vanityPath]/components/HeroSection.tsx
+++ b/app/[vanityPath]/components/HeroSection.tsx
@@ -19,7 +19,6 @@ export default function HeroSection({
   const imageWidth = imageDimensions?.width || 1280
   const imageHeight = imageDimensions?.height || 640
 
-
   return (
     <section className={`py-16 ${activeTheme.secondary}`}>
       <div className="max-w-6xl mx-auto px-8 flex-col md:flex-row flex gap-16 justify-between items-stretch md:items-center">
@@ -32,14 +31,14 @@ export default function HeroSection({
             {content?.main?.title || ''}
           </h1>
           <p className="text-xl mb-8">{content?.main?.tagline || ''}</p>
-          <Link to={WEBSITE_SECTIONS.CONTACT}  smooth duration={500}>
+          <Link to={WEBSITE_SECTIONS.CONTACT} smooth duration={500}>
             <Button
               className={`inline-block`}
               color="primary"
               size="large"
               theme={{
                 accent: activeTheme.accent,
-                accentText: activeTheme.accentText
+                accentText: activeTheme.accentText,
               }}
             >
               Send a Message

--- a/app/[vanityPath]/components/PrivacyPolicyModal.tsx
+++ b/app/[vanityPath]/components/PrivacyPolicyModal.tsx
@@ -42,14 +42,14 @@ export default function PrivacyPolicyModal({
       theme={{
         bg: activeTheme.bg,
         text: activeTheme.text,
-        border: activeTheme.border
+        border: activeTheme.border,
       }}
     >
       <div className="mb-4">
-        <h3 className="font-semibold text-lg mb-2">{content?.main?.title || ''}</h3>
-        <p className="text-sm mb-4">
-          Last Updated: {currentDate}
-        </p>
+        <h3 className="font-semibold text-lg mb-2">
+          {content?.main?.title || ''}
+        </h3>
+        <p className="text-sm mb-4">Last Updated: {currentDate}</p>
       </div>
       <div className="space-y-4 text-sm">
         <div>

--- a/app/[vanityPath]/components/SmsTermsModal.tsx
+++ b/app/[vanityPath]/components/SmsTermsModal.tsx
@@ -56,8 +56,8 @@ export default function SmsTermsModal({
           <p>
             By opting in, you agree to receive SMS messages from the{' '}
             {campaignName} campaign. Messages may include campaign updates,
-            volunteer opportunities, event notifications, fundraising
-            requests, and other campaign-related communications.
+            volunteer opportunities, event notifications, fundraising requests,
+            and other campaign-related communications.
           </p>
         </div>
         <div>
@@ -70,8 +70,8 @@ export default function SmsTermsModal({
         <div>
           <h3 className="font-medium">Message and Data Rates</h3>
           <p>
-            Message and data rates may apply. Check with your mobile carrier
-            for details.
+            Message and data rates may apply. Check with your mobile carrier for
+            details.
           </p>
         </div>
         <div>
@@ -91,9 +91,7 @@ export default function SmsTermsModal({
         </div>
         <div>
           <h3 className="font-medium">Carrier Disclaimer</h3>
-          <p>
-            Carriers are not liable for delayed or undelivered messages.
-          </p>
+          <p>Carriers are not liable for delayed or undelivered messages.</p>
         </div>
         <div>
           <h3 className="font-medium">Privacy</h3>
@@ -111,9 +109,7 @@ export default function SmsTermsModal({
         </div>
         <div>
           <h3 className="font-medium">Contact</h3>
-          {content?.contact?.email && (
-            <p>Email: {content.contact.email}</p>
-          )}
+          {content?.contact?.email && <p>Email: {content.contact.email}</p>}
           {content?.contact?.phone && <p>Phone: {content.contact.phone}</p>}
           {content?.contact?.address && (
             <p>Address: {content.contact.address}</p>

--- a/app/[vanityPath]/components/WebsiteHeader.tsx
+++ b/app/[vanityPath]/components/WebsiteHeader.tsx
@@ -27,7 +27,9 @@ export default function WebsiteHeader({
               priority
             />
           ) : candidate ? (
-            <span className={`text-xl font-medium border ${activeTheme.border} rounded-md px-4 py-2 truncate`}>
+            <span
+              className={`text-xl font-medium border ${activeTheme.border} rounded-md px-4 py-2 truncate`}
+            >
               {getUserFullName(candidate)}
             </span>
           ) : (
@@ -43,7 +45,12 @@ export default function WebsiteHeader({
         </div>
         <ul className="flex space-x-6 list-none">
           <li>
-            <Link to={WEBSITE_SECTIONS.ABOUT}  smooth duration={500} className="hover:opacity-80 cursor-pointer">
+            <Link
+              to={WEBSITE_SECTIONS.ABOUT}
+              smooth
+              duration={500}
+              className="hover:opacity-80 cursor-pointer"
+            >
               About
             </Link>
           </li>

--- a/app/[vanityPath]/components/WebsitePage.tsx
+++ b/app/[vanityPath]/components/WebsitePage.tsx
@@ -2,7 +2,10 @@
 import { useState, useEffect } from 'react'
 import { animateScroll as scroll, scroller } from 'react-scroll'
 import { WEBSITE_THEMES } from '../constants/websiteContent.const'
-import { WEBSITE_SECTIONS, WEBSITE_STEPS } from '../constants/websiteNavigation.const'
+import {
+  WEBSITE_SECTIONS,
+  WEBSITE_STEPS,
+} from '../constants/websiteNavigation.const'
 import { Website } from '../types/website.type'
 import WebsiteHeader from './WebsiteHeader'
 import HeroSection from './HeroSection'
@@ -38,7 +41,9 @@ export default function WebsitePage({
   privacyPolicy?: boolean
   smsTerms?: boolean
 }) {
-  const [showPrivacyPolicy, setShowPrivacyPolicy] = useState(privacyPolicy || false)
+  const [showPrivacyPolicy, setShowPrivacyPolicy] = useState(
+    privacyPolicy || false,
+  )
   const [showSmsTerms, setShowSmsTerms] = useState(smsTerms || false)
   const content = website?.content || {}
   const activeTheme =
@@ -51,7 +56,7 @@ export default function WebsitePage({
     if (!isPreview || step === null || step === undefined) return
 
     const scrollToSection = () => {
-      if ( step === WEBSITE_STEPS.CONTACT_INTRO) {
+      if (step === WEBSITE_STEPS.CONTACT_INTRO) {
         scroller.scrollTo(WEBSITE_SECTIONS.ABOUT, {
           ...scrollSettings,
         })
@@ -89,7 +94,11 @@ export default function WebsitePage({
     >
       <WebsiteViewTracker vanityPath={website.vanityPath} />
       <WebsiteHeader activeTheme={activeTheme} website={website} />
-      <HeroSection activeTheme={activeTheme} content={content} imageDimensions={imageDimensions} />
+      <HeroSection
+        activeTheme={activeTheme}
+        content={content}
+        imageDimensions={imageDimensions}
+      />
       <AboutSection activeTheme={activeTheme} content={content} />
       <ContactSection
         activeTheme={activeTheme}

--- a/app/[vanityPath]/constants/websiteNavigation.const.ts
+++ b/app/[vanityPath]/constants/websiteNavigation.const.ts
@@ -11,4 +11,4 @@ export const WEBSITE_STEPS = {
   ABOUT_COMPLETE: 4,
   CONTACT_INTRO: 5,
   CONTACT_INFO: 6,
-} as const 
+} as const

--- a/app/[vanityPath]/page.tsx
+++ b/app/[vanityPath]/page.tsx
@@ -3,7 +3,10 @@ import { fetchHelper } from '@/helpers/fetchHelper'
 import WebsitePage from './components/WebsitePage'
 import { Website } from './types/website.type'
 import { getCandidateMetaData } from '../shared/utils/candidateMetaData'
-import { getImageDimensionsServer, ImageDimensions } from '../shared/utils/getImageDimensions'
+import {
+  getImageDimensionsServer,
+  ImageDimensions,
+} from '../shared/utils/getImageDimensions'
 
 export interface PageProps {
   params: Promise<{ vanityPath: string }>
@@ -31,7 +34,10 @@ export async function generateMetadata({ params }: PageProps) {
   return getCandidateMetaData(website)
 }
 
-export default async function CandidateWebsitePage({ params, searchParams }: PageProps) {
+export default async function CandidateWebsitePage({
+  params,
+  searchParams,
+}: PageProps) {
   const website = await getWebsite(await params)
   const { privacy, 'sms-terms': smsTerms } = await searchParams
 

--- a/app/[vanityPath]/preview/PreviewPageClient.tsx
+++ b/app/[vanityPath]/preview/PreviewPageClient.tsx
@@ -5,8 +5,6 @@ import { notFound } from 'next/navigation'
 import WebsitePage from '../components/WebsitePage'
 import { Website } from '../types/website.type'
 
-
-
 export default function PreviewPageClient() {
   const [website, setWebsite] = useState<Website | null>(null)
   const [step, setStep] = useState<number | null>(null)

--- a/app/[vanityPath]/preview/page.tsx
+++ b/app/[vanityPath]/preview/page.tsx
@@ -1,10 +1,8 @@
 import PreviewPageClient from './PreviewPageClient'
 
-
 export const revalidate = 3600
 export const dynamic = 'force-dynamic'
 
 export default async function CandidateWebsitePage() {
-
   return <PreviewPageClient />
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,11 @@ export async function generateMetadata() {
   return getCandidateMetaData(website)
 }
 
-export default async function Home({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
   const { privacy, 'sms-terms': smsTerms } = await searchParams
 
   const headersList = await headers()

--- a/app/shared/buttons/Button.tsx
+++ b/app/shared/buttons/Button.tsx
@@ -132,9 +132,10 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       SIZE_CLASSES[size as keyof typeof SIZE_CLASSES] || SIZE_CLASSES.medium
 
     // Use theme colors if provided, otherwise use default color classes
-    const finalColorClasses = theme?.accent && theme?.accentText 
-      ? `${theme.accent} ${theme.accentText} hover:opacity-80` 
-      : colorClasses
+    const finalColorClasses =
+      theme?.accent && theme?.accentText
+        ? `${theme.accent} ${theme.accentText} hover:opacity-80`
+        : colorClasses
 
     const compiledClassName = `${baseClasses} ${sizeClasses} ${finalColorClasses} ${
       className || ''

--- a/app/shared/inputs/Checkbox.tsx
+++ b/app/shared/inputs/Checkbox.tsx
@@ -14,18 +14,20 @@ interface CheckboxProps extends MuiCheckboxProps {
 }
 
 const Checkbox = ({ label, name, theme, ...restProps }: CheckboxProps) => {
-  const sx = theme?.muiColor ? {
-    color: theme.muiColor,
-    '&.Mui-checked': {
-      color: theme.muiColor,
-    },
-    '& .MuiSvgIcon-root': {
-      fill: theme.muiColor,
-    },
-    '&.Mui-checked .MuiSvgIcon-root': {
-      fill: theme.muiColor,
-    },
-  } : undefined
+  const sx = theme?.muiColor
+    ? {
+        color: theme.muiColor,
+        '&.Mui-checked': {
+          color: theme.muiColor,
+        },
+        '& .MuiSvgIcon-root': {
+          fill: theme.muiColor,
+        },
+        '&.Mui-checked .MuiSvgIcon-root': {
+          fill: theme.muiColor,
+        },
+      }
+    : undefined
 
   return label ? (
     <FormControlLabel

--- a/app/shared/inputs/EmailInput.tsx
+++ b/app/shared/inputs/EmailInput.tsx
@@ -8,8 +8,10 @@ import { TextFieldProps } from '@mui/material'
 // NOTE: leaving export here for now to not break existing imports
 export { isValidEmail }
 
-interface EmailInputProps
-  extends Omit<TextFieldProps, 'onChange' | 'onChangeCallback'> {
+interface EmailInputProps extends Omit<
+  TextFieldProps,
+  'onChange' | 'onChangeCallback'
+> {
   value: string
   onChangeCallback: (e: ChangeEvent<HTMLInputElement>) => void
   onBlurCallback?: (e: any) => void

--- a/app/shared/utils/ImageWithDimensions.tsx
+++ b/app/shared/utils/ImageWithDimensions.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useEffect } from 'react'
 import Image from 'next/image'
-import { getImageDimensionsWithFallback, ImageDimensions } from './getImageDimensions'
+import {
+  getImageDimensionsWithFallback,
+  ImageDimensions,
+} from './getImageDimensions'
 
 interface ImageWithDimensionsProps {
   src: string
@@ -19,7 +22,7 @@ export default function ImageWithDimensions({
   src,
   alt,
   className = '',
-  fallbackDimensions = { width: 1280, height: 640 }
+  fallbackDimensions = { width: 1280, height: 640 },
 }: ImageWithDimensionsProps) {
   const [dimensions, setDimensions] = useState<ImageDimensions | null>(null)
   const [loading, setLoading] = useState(true)
@@ -33,10 +36,17 @@ export default function ImageWithDimensions({
       setError(null)
 
       try {
-        const imageDimensions = await getImageDimensionsWithFallback(src, fallbackDimensions)
+        const imageDimensions = await getImageDimensionsWithFallback(
+          src,
+          fallbackDimensions,
+        )
         setDimensions(imageDimensions)
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load image dimensions')
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to load image dimensions',
+        )
         setDimensions(fallbackDimensions)
       } finally {
         setLoading(false)
@@ -60,15 +70,16 @@ export default function ImageWithDimensions({
         className="w-full object-contain"
         priority
       />
-      
+
       {/* Optional: Display dimension info (for debugging/development) */}
       {process.env.NODE_ENV === 'development' && (
         <div className="absolute top-2 left-2 bg-black bg-opacity-70 text-white px-2 py-1 text-xs rounded">
           {loading && 'Loading dimensions...'}
           {error && `Error: ${error}`}
-          {dimensions && !loading && !error && 
-            `${dimensions.width} × ${dimensions.height}`
-          }
+          {dimensions &&
+            !loading &&
+            !error &&
+            `${dimensions.width} × ${dimensions.height}`}
         </div>
       )}
     </div>

--- a/app/shared/utils/Paper.tsx
+++ b/app/shared/utils/Paper.tsx
@@ -11,11 +11,16 @@ interface PaperProps {
   [key: string]: any
 }
 
-export default function Paper({ children, className, theme, ...rest }: PaperProps) {
+export default function Paper({
+  children,
+  className,
+  theme,
+  ...rest
+}: PaperProps) {
   const bgClass = theme?.bg || 'bg-white'
   const textClass = theme?.text || 'text-gray-800'
   const borderClass = theme?.border || 'border-black/[0.12]'
-  
+
   return (
     <div
       className={`${bgClass} ${textClass} border ${borderClass} p-4 md:p-6 rounded-xl ${

--- a/app/shared/utils/ResponsiveModal.tsx
+++ b/app/shared/utils/ResponsiveModal.tsx
@@ -81,7 +81,11 @@ export default function ResponsiveModal({
         `}
         theme={theme}
       >
-        {title && <H5 className="absolute top-6 left-4 lg:left-8 xl:left-16">{title}</H5>}
+        {title && (
+          <H5 className="absolute top-6 left-4 lg:left-8 xl:left-16">
+            {title}
+          </H5>
+        )}
         {!hideClose && (
           <CloseRounded
             className="cursor-pointer absolute top-6 right-4"

--- a/app/shared/utils/getImageDimensions.ts
+++ b/app/shared/utils/getImageDimensions.ts
@@ -15,7 +15,9 @@ export function getImageDimensions(imageUrl: string): Promise<ImageDimensions> {
   return new Promise((resolve, reject) => {
     // Check if we're in a browser environment
     if (typeof window === 'undefined') {
-      reject(new Error('getImageDimensions can only be used in browser environment'))
+      reject(
+        new Error('getImageDimensions can only be used in browser environment'),
+      )
       return
     }
 
@@ -25,18 +27,18 @@ export function getImageDimensions(imageUrl: string): Promise<ImageDimensions> {
     }
 
     const img = new Image()
-    
+
     img.onload = () => {
       resolve({
         width: img.naturalWidth,
-        height: img.naturalHeight
+        height: img.naturalHeight,
       })
     }
-    
+
     img.onerror = (error) => {
       reject(new Error(`Failed to load image: ${imageUrl}. ${error}`))
     }
-    
+
     // Handle CORS for S3 URLs
     img.crossOrigin = 'anonymous'
     img.src = imageUrl
@@ -51,7 +53,7 @@ export function getImageDimensions(imageUrl: string): Promise<ImageDimensions> {
  */
 export async function getImageDimensionsWithFallback(
   imageUrl: string,
-  fallback?: ImageDimensions
+  fallback?: ImageDimensions,
 ): Promise<ImageDimensions | null> {
   try {
     return await getImageDimensions(imageUrl)
@@ -67,27 +69,38 @@ export async function getImageDimensionsWithFallback(
  * @param imageUrl - The URL of the image to get dimensions for
  * @returns Promise that resolves to dimensions
  */
-export async function getImageDimensionsServer(imageUrl: string): Promise<ImageDimensions> {
+export async function getImageDimensionsServer(
+  imageUrl: string,
+): Promise<ImageDimensions> {
   try {
     const response = await fetch(imageUrl)
     if (!response.ok) {
-      throw new Error(`Failed to fetch image: ${response.status} ${response.statusText}`)
+      throw new Error(
+        `Failed to fetch image: ${response.status} ${response.statusText}`,
+      )
     }
-    
+
     const buffer = await response.arrayBuffer()
     const uint8Array = new Uint8Array(buffer)
-    
+
     // Basic JPEG dimension parsing
-    if (uint8Array[0] === 0xFF && uint8Array[1] === 0xD8) {
+    if (uint8Array[0] === 0xff && uint8Array[1] === 0xd8) {
       return parseJPEGDimensions(uint8Array)
     }
-    
+
     // Basic PNG dimension parsing
-    if (uint8Array[0] === 0x89 && uint8Array[1] === 0x50 && uint8Array[2] === 0x4E && uint8Array[3] === 0x47) {
+    if (
+      uint8Array[0] === 0x89 &&
+      uint8Array[1] === 0x50 &&
+      uint8Array[2] === 0x4e &&
+      uint8Array[3] === 0x47
+    ) {
       return parsePNGDimensions(uint8Array)
     }
-    
-    throw new Error('Unsupported image format. Only JPEG and PNG are supported.')
+
+    throw new Error(
+      'Unsupported image format. Only JPEG and PNG are supported.',
+    )
   } catch (error) {
     throw new Error(`Failed to get image dimensions: ${error}`)
   }
@@ -98,24 +111,24 @@ export async function getImageDimensionsServer(imageUrl: string): Promise<ImageD
  */
 function parseJPEGDimensions(buffer: Uint8Array): ImageDimensions {
   let offset = 2 // Skip SOI marker
-  
+
   while (offset < buffer.length) {
-    if (buffer[offset] !== 0xFF) break
-    
+    if (buffer[offset] !== 0xff) break
+
     const marker = buffer[offset + 1]
-    
+
     // SOF0, SOF1, SOF2 markers contain dimension info
-    if (marker >= 0xC0 && marker <= 0xC3) {
+    if (marker >= 0xc0 && marker <= 0xc3) {
       const height = (buffer[offset + 5] << 8) | buffer[offset + 6]
       const width = (buffer[offset + 7] << 8) | buffer[offset + 8]
       return { width, height }
     }
-    
+
     // Skip to next marker
     const segmentLength = (buffer[offset + 2] << 8) | buffer[offset + 3]
     offset += 2 + segmentLength
   }
-  
+
   throw new Error('Could not parse JPEG dimensions')
 }
 
@@ -124,8 +137,10 @@ function parseJPEGDimensions(buffer: Uint8Array): ImageDimensions {
  */
 function parsePNGDimensions(buffer: Uint8Array): ImageDimensions {
   // PNG width is at bytes 16-19, height at bytes 20-23
-  const width = (buffer[16] << 24) | (buffer[17] << 16) | (buffer[18] << 8) | buffer[19]
-  const height = (buffer[20] << 24) | (buffer[21] << 16) | (buffer[22] << 8) | buffer[23]
-  
+  const width =
+    (buffer[16] << 24) | (buffer[17] << 16) | (buffer[18] << 8) | buffer[19]
+  const height =
+    (buffer[20] << 24) | (buffer[21] << 16) | (buffer[22] << 8) | buffer[23]
+
   return { width, height }
 }

--- a/app/shared/utils/phoneFormatter.ts
+++ b/app/shared/utils/phoneFormatter.ts
@@ -5,8 +5,7 @@ export default function formatPhoneNumber(phoneNumber: string) {
   return parsedPhoneNumber?.formatNational() || phoneNumber
 }
 
-
 export function phoneUri(phoneNumber: string) {
-    const parsedPhoneNumber = parsePhoneNumber(phoneNumber, 'US')
-    return parsedPhoneNumber?.getURI() || phoneNumber
-  }
+  const parsedPhoneNumber = parsePhoneNumber(phoneNumber, 'US')
+  return parsedPhoneNumber?.getURI() || phoneNumber
+}

--- a/appEnv.ts
+++ b/appEnv.ts
@@ -7,7 +7,7 @@ export const IS_DEV =
 export const IS_LOCAL =
   Boolean(
     typeof process !== 'undefined' &&
-      process?.env?.NEXT_PUBLIC_API_BASE?.includes('localhost'),
+    process?.env?.NEXT_PUBLIC_API_BASE?.includes('localhost'),
   ) ||
   Boolean(
     typeof window !== 'undefined' && window.location.href.includes('localhost'),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,13 +11,7 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   {
-    ignores: [
-      '.next/**',
-      'out/**',
-      'build/**',
-      'next-env.d.ts',
-      'ai-rules/**',
-    ],
+    ignores: ['.next/**', 'out/**', 'build/**', 'next-env.d.ts', 'ai-rules/**'],
   },
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   ...compat.config({

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-unused-imports": "^4.1.4",
         "postcss": "^8.4.24",
-        "prettier": "^2.7.1",
+        "prettier": "^3.8.3",
         "tailwindcss": "^3.2.1",
         "typescript": "^5"
       }
@@ -6030,16 +6030,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-unused-imports": "^4.1.4",
     "postcss": "^8.4.24",
-    "prettier": "^2.7.1",
+    "prettier": "^3.8.3",
     "tailwindcss": "^3.2.1",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Monorepo prep

Bumps `prettier` `^2.7.1` -> `^3.x` and runs `prettier --write .` across the repo so the upcoming **omni** monorepo can standardize on Prettier 3.

### Changes
- `prettier` `^2.7.1` -> `^3.8.3`
- Repo-wide reformat (`prettier --write .`). **Purely mechanical, no behavioral changes.**
- `.prettierrc` unchanged (`semi: false`, single quotes, `trailingComma: all`, `printWidth: 80`)

### Diff size
25 files changed, +328 / -258. Mostly markdown table alignment + trailing-whitespace trimming; the only sizable source reformat is `app/[vanityPath]/components/ContactSection.tsx`. Kept in its own PR precisely because of the noise.

### Validation (local — repo has no CI today)
- `prettier -c .` -> all files match
- `npm run lint` passes (1 pre-existing warning)
- `npm run build` succeeds

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and formatting-only changes; no auth, data, or business-logic edits.
> 
> **Overview**
> Upgrades **Prettier** from `^2.7.1` to `^3.8.3` (with lockfile) ahead of monorepo standardization, then applies a **repo-wide** `prettier --write` pass. `.prettierrc` is unchanged.
> 
> The diff is almost entirely formatting: markdown table alignment, trailing commas, line wraps, and EOF newlines. The largest source churn is `ContactSection.tsx` (indentation/line breaks only). No intended runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 947b1c9234602513bba9c1de97516729f5dcdd46. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->